### PR TITLE
feat: add -p short option for --print-path-only (Task 8-1)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ pub enum Commands {
     List {
         #[arg(short, long, default_value = DEFAULT_CONFIG_FILE)]
         config: String,
-        #[arg(long, help = "Print selected workspace path only")]
+        #[arg(short = 'p', long, help = "Print selected workspace path only")]
         print_path_only: bool,
     },
 }
@@ -136,6 +136,24 @@ mod tests {
     }
 
     #[test]
+    fn test_cli_list_command_with_short_print_path_only() {
+        // list コマンドに-pフラグを指定
+        let args = vec!["ai-workspace", "list", "-p"];
+        let cli = Cli::try_parse_from(args).unwrap();
+
+        match cli.command {
+            Commands::List {
+                config,
+                print_path_only,
+            } => {
+                assert_eq!(config, DEFAULT_CONFIG_FILE);
+                assert!(print_path_only);
+            }
+            _ => panic!("Expected List command"),
+        }
+    }
+
+    #[test]
     fn test_cli_list_command_with_both_options() {
         // list コマンドに両方のオプションを指定
         let args = vec![
@@ -145,6 +163,24 @@ mod tests {
             "test.yml",
             "--print-path-only",
         ];
+        let cli = Cli::try_parse_from(args).unwrap();
+
+        match cli.command {
+            Commands::List {
+                config,
+                print_path_only,
+            } => {
+                assert_eq!(config, "test.yml");
+                assert!(print_path_only);
+            }
+            _ => panic!("Expected List command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_list_command_with_both_options_short() {
+        // list コマンドに両方のオプション（短縮形）を指定
+        let args = vec!["ai-workspace", "list", "-c", "test.yml", "-p"];
         let cli = Cli::try_parse_from(args).unwrap();
 
         match cli.command {


### PR DESCRIPTION
## Summary
Task 8-1の実装: `--print-path-only`オプションに`-p`ショートオプションを追加しました。

### 変更内容

- **CLI改善**: `gwork list --print-path-only`に`-p`ショートオプションを追加
- **後方互換性**: 既存の`--print-path-only`オプションも引き続き利用可能
- **テスト強化**: 新しいショートオプションのテストケースを追加

### 使用例

```bash
# ショートオプション（新機能）
gwork list -p

# ロングオプション（既存機能）
gwork list --print-path-only

# 組み合わせも可能
gwork list -c custom.yml -p
```

### テスト項目

- [x] `-p`オプションが正常に動作する
- [x] `--print-path-only`オプションが引き続き動作する
- [x] ヘルプメッセージで`-p`オプションが表示される
- [x] 両方のオプションが同じ結果を返す
- [x] 全テストケースが通過する

## Test plan
- [x] CLI機能テスト
- [x] ユニットテスト実行
- [x] ヘルプメッセージ確認
- [x] 後方互換性確認

🤖 Generated with [Claude Code](https://claude.ai/code)